### PR TITLE
chore(type): add customize icon type of index.d.ts, closed #18

### DIFF
--- a/package/dist/index.d.ts
+++ b/package/dist/index.d.ts
@@ -106,4 +106,4 @@ declare const OhVueIcon: vue_demi.DefineComponent<{
     inverse: boolean;
 }>;
 
-export { OhVueIcon, addIcons, listIcons };
+export { CustomizeIconType, OhVueIcon, addIcons, listIcons };

--- a/package/src/components/Icon.ts
+++ b/package/src/components/Icon.ts
@@ -358,4 +358,4 @@ const OhVueIcon = defineComponent({
   }
 });
 
-export { CustomizeIconType, OhVueIcon, addIcons, listIcons };
+export { OhVueIcon, addIcons, listIcons };

--- a/package/src/components/Icon.ts
+++ b/package/src/components/Icon.ts
@@ -358,4 +358,4 @@ const OhVueIcon = defineComponent({
   }
 });
 
-export { OhVueIcon, addIcons, listIcons };
+export { CustomizeIconType, OhVueIcon, addIcons, listIcons };

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,2 +1,5 @@
+import type { CustomizeIconType } from "../types/icons";
+
+export type { CustomizeIconType };
 export * from "./components/Icon";
 import "./styles";


### PR DESCRIPTION
### Why:
My icons array is not well supported and type checked when I use typescript
```ts
const icons = [
  {
    name: "mail",
    width: 24,
    height: 24,
    d: "M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-1 14H5c-.55 0-1-.45-1-1V8l6.94 4.34c.65.41 1.47.41 2.12 0L20 8v9c0 .55-.45 1-1 1zm-7-7L4 6h16l-8 5z"
  }
];
addIcons(...icons);
```

### Expect
```ts
import type { CustomizeIconType } from "oh-vue-icons";
const icons: CustomizeIconType[] = [
  {
    name: "mail",
    width: 24,
    height: 24,
    d: "M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-1 14H5c-.55 0-1-.45-1-1V8l6.94 4.34c.65.41 1.47.41 2.12 0L20 8v9c0 .55-.45 1-1 1zm-7-7L4 6h16l-8 5z"
  }
];
addIcons(...icons);
```