### PR TITLE
Update templates.js

### DIFF
--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -4,7 +4,8 @@ const packageJsonTemplate =
   JSON.stringify(
     {
       sideEffects: false,
-      module: "./index.js"
+      module: "./index.js",
+      type: "module"
     },
     null,
     2


### PR DESCRIPTION
Updated package.json template to include ```type: "module"```.

This allows loading icons as ES Modules in NPM.

Bug found while testing SSR with Vite + Laravel + Inertia. This PR fixes the issue.

Solution to this issue was provided from: https://stackoverflow.com/a/40021867

Quick and easy fix.

![image](https://github.com/MiB3Avenger/oh-vue-icons/assets/30885075/7c270852-4d52-4ba7-96b9-502c40da0817)

Ps: This is my first time contributing by using a fork. I'm sorry if the description is not much detailed. If there are much easier ways to do the same thing while using oh vue icons that doesn't require a PR, please let me know. At the moment, I am using my own fork for my project, but I hope this allows others to make use of this fix.